### PR TITLE
changed order, added tooltip

### DIFF
--- a/packages/core/src/components/OnboardingNavigationMainItem.svelte
+++ b/packages/core/src/components/OnboardingNavigationMainItem.svelte
@@ -92,11 +92,11 @@
 
 <div class="toggle-button">
   {#if $showOnboardingNavigation}
-    <span on:click={toggleNavigation}>
+    <span title="Disable navigation steps" on:click={toggleNavigation}>
       <i class="fas fa-solid fa-toggle-on" />
     </span>
   {:else}
-    <span on:click={toggleNavigation}>
+    <span title="Enable navigation steps" on:click={toggleNavigation}>
       <i
         class="fas fa-solid fa-toggle-off"
         style="width: 20px, height:20px"
@@ -155,7 +155,7 @@
 
   .visahoi-delete-stage {
     position: absolute;
-    margin-left: 110px;
+    margin-left: 80px;
   }
 
   .fa-trash {

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -133,7 +133,7 @@ export const defaultOnboardingStages: Map<
       hoverBackgroundColor: "rgb(92, 59, 112)",
       backgroundColor: "rgb(123, 80, 150)",
       activeBackgroundColor: "rgb(76, 46, 94)",
-      order: 1,
+      order: 3,
     },
   ],
   [
@@ -153,7 +153,7 @@ export const defaultOnboardingStages: Map<
       title: "Analyzing",
       iconClass: "fas fa-lightbulb",
       backgroundColor: "rgb(254, 128, 41)",
-      order: 3,
+      order: 1,
     },
   ],
 ]);

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -89,7 +89,6 @@ const getAhoiConfig = () => {
   setOnboardingStage({
     id: 'using-the-chart',
     title: 'Interact',
-    order: 4,
   });
 
   const ahoiConfig = {


### PR DESCRIPTION
Summary :
* Changed the order of onboarding stages.
* Added tooltip 
* Changed the margin for trash icon for delete onboarding stage.

ToDo: 

The navigation stepper navigation is arranged in descending order. ie, For example, in the screenshot it opens the 2nd marker of Reading. But he wants it to be the 1st marker of reading .

![image](https://user-images.githubusercontent.com/104566246/186725909-60690308-369c-4667-a9ee-9c4f274713d0.png)
