### PR TITLE
add order to onboarding messages

### DIFF
--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -46,6 +46,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-2",
       },
+      order: 2,
     },
     {
       anchor: getAnchor(spec.yAxisTitle, visElement),
@@ -56,6 +57,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-3",
       },
+      order: 3,
     },
     {
       anchor: getAnchor(spec.xAxisTitle, visElement),
@@ -66,6 +68,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-4",
       },
+      order: 4,
     },
     {
       anchor: getAnchor(spec.yMin, visElement),
@@ -76,6 +79,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-5",
       },
+      order: 1,
     },
     {
       anchor: getAnchor(spec.yMax, visElement),
@@ -86,6 +90,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-6",
       },
+      order: 2,
     },
   ];
 
@@ -99,6 +104,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-1",
       },
+      order: 1,
     });
   }
 

--- a/packages/core/src/change-matrix.ts
+++ b/packages/core/src/change-matrix.ts
@@ -36,6 +36,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-2",
       },
+      order: 2,
     },
     {
       anchor: getAnchor(spec.legendTitle, visElement),
@@ -46,6 +47,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-3",
       },
+      order: 3,
     },
     {
       anchor: getAnchor(spec.xAxis, visElement),
@@ -56,6 +58,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-4",
       },
+      order: 4,
     },
   ];
 
@@ -73,6 +76,7 @@ function generateMessages(
         fontSize: "20px",
         id: "unique-marker-id-1",
       },
+      order: 1,
     });
   }
 

--- a/packages/core/src/components/Markers.svelte
+++ b/packages/core/src/components/Markers.svelte
@@ -8,10 +8,21 @@
     markerInformation,
   } from "./stores";
   import Marker from "./Marker.svelte";
+  import Backdrop from "./Backdrop.svelte";
 
   $: viewBox = `${$visXPosition + window.scrollX} ${
     $visYPosition + window.scrollY
   } ${$visWidth} ${$visHeight}`;
+
+  $: markInfo = $markerInformation.sort((a, b) => {
+    if (a.message.onboardingStage.title === b.message.onboardingStage.title) {
+      return a.message?.order > b.message?.order ? -1 : 1;
+    } else {
+      return a.message.onboardingStage.title > b.message.onboardingStage.title
+        ? -1
+        : 1;
+    }
+  });
 
   let currentOnboardingStage;
   activeOnboardingStage.subscribe((value) => {
@@ -20,7 +31,7 @@
 </script>
 
 <svg {viewBox} class="visahoi-markers">
-  {#each $markerInformation.filter((m) => m.message.onboardingStage.id === $activeOnboardingStage?.id) as marker, index}
+  {#each markInfo.filter((m) => m.message.onboardingStage.id === $activeOnboardingStage?.id) as marker, index}
     <Marker markerInformation={marker} order={index + 1} />
   {/each}
 </svg>

--- a/packages/core/src/components/Markers.svelte
+++ b/packages/core/src/components/Markers.svelte
@@ -14,16 +14,6 @@
     $visYPosition + window.scrollY
   } ${$visWidth} ${$visHeight}`;
 
-  $: markInfo = $markerInformation.sort((a, b) => {
-    if (a.message.onboardingStage.title === b.message.onboardingStage.title) {
-      return a.message?.order > b.message?.order ? -1 : 1;
-    } else {
-      return a.message.onboardingStage.title > b.message.onboardingStage.title
-        ? -1
-        : 1;
-    }
-  });
-
   let currentOnboardingStage;
   activeOnboardingStage.subscribe((value) => {
     currentOnboardingStage = value?.id;
@@ -31,7 +21,7 @@
 </script>
 
 <svg {viewBox} class="visahoi-markers">
-  {#each markInfo.filter((m) => m.message.onboardingStage.id === $activeOnboardingStage?.id) as marker, index}
+  {#each $markerInformation.filter((m) => m.message.onboardingStage.id === $activeOnboardingStage?.id) as marker, index}
     <Marker markerInformation={marker} order={index + 1} />
   {/each}
 </svg>

--- a/packages/core/src/components/NavigationMarker.svelte
+++ b/packages/core/src/components/NavigationMarker.svelte
@@ -14,7 +14,7 @@
   export let markerInformation: IMarkerInformation;
   export let order: number;
 
-  $: bottom = order * 35 + 15 + "px";
+  // $: bottom = order * 35 + 15 + "px";
 
   const { activeBackgroundColor, hoverBackgroundColor, backgroundColor } =
     markerInformation.message.onboardingStage;
@@ -23,11 +23,20 @@
   let arrValue: IMarkerInformation[] = [];
 
   /**First navigation marker which belongs to the activeOnboarding stage is selected */
+  // $markInfo.map(async (message) => {
+  //   if (
+  //     message.message.onboardingStage.title === $activeOnboardingStage?.title
+  //   ) {
+  //     arrValue.push(message);
+  //   }
+  // });
+
   $markInfo.map(async (message) => {
     if (
       message.message.onboardingStage.title === $activeOnboardingStage?.title
     ) {
       arrValue.push(message);
+      // selectedMarker.set(arrValue[arrValue.length - 1]);
       selectedMarker.set(arrValue[0]);
 
       activeOnboardingStage.update(
@@ -99,13 +108,11 @@
     } else {
       activeMarker.set(markerInformation);
     }
+    console.log($activeMarker, "Active marker");
   };
 </script>
 
-<div
-  style="--bottom:{bottom}"
-  class="visahoi-marker-navigation-item {$activeOnboardingStage}"
->
+<div class="visahoi-navigation-wrapper">
   <div
     on:click={handleClick}
     style="--active-background-color:{activeBackgroundColor ||
@@ -118,6 +125,12 @@
 </div>
 
 <style>
+  .visahoi-navigation-wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 8px;
+  }
   .visahoi-marker-navigation-item {
     position: absolute;
     display: flex;

--- a/packages/core/src/components/OnboardingNavigation.svelte
+++ b/packages/core/src/components/OnboardingNavigation.svelte
@@ -134,44 +134,46 @@
   class="visahoi-navigation-container"
   style="--flexDirection:{$navigationAlignment}; height: '60px' "
 >
-  <div class="visahoi-navigation-marker-container">
-    <!-- {#if $activeOnboardingStage && $showOnboardingNavigation}
+  {#key $markerInformation}
+    <div class="visahoi-navigation-marker-container">
+      <!-- {#if $activeOnboardingStage && $showOnboardingNavigation}
       {#each $markerInformation.sort( (a, b) => (a.message.onboardingStage.title < b.message.onboardingStage.title ? -1 : a.message.onboardingStage.title > b.message.onboardingStage.title ? 1 : 0) ) as marker, index}
         <NavigationMarker markerInformation={marker} order={index + 1} />
       {/each}
     {/if} -->
 
-    {#if $activeOnboardingStage && $showOnboardingNavigation}
-      {#each $markerInformation.sort((a, b) => {
-        if (a.message.onboardingStage.title === b.message.onboardingStage.title) {
-          return a.message?.order < b.message?.order ? -1 : 1;
-        } else {
-          return a.message.onboardingStage.title > b.message.onboardingStage.title ? -1 : 1;
-        }
-      }) as marker, index}
-        <NavigationMarker markerInformation={marker} order={index + 1} />
-      {/each}
-    {/if}
+      {#if $activeOnboardingStage && $showOnboardingNavigation}
+        {#each $markerInformation.sort((a, b) => {
+          if (a.message.onboardingStage.title === b.message.onboardingStage.title) {
+            return a.message?.order < b.message?.order ? -1 : 1;
+          } else {
+            return a.message.onboardingStage.title > b.message.onboardingStage.title ? -1 : 1;
+          }
+        }) as marker, index}
+          <NavigationMarker markerInformation={marker} order={index + 1} />
+        {/each}
+      {/if}
 
-    {#if $activeOnboardingStage && $showOnboardingNavigation}
-      <div
-        id="navigation-next"
-        style="--bottom-height: {nextHeight}"
-        class="visahoi-navigation-next"
-        on:click={navPrev}
-      >
-        <span><i class="fas fa-chevron-up" /></span>
-      </div>
-      <div
-        id="navigation-previous"
-        style="--bottom-height: {prevHeight}"
-        class="visahoi-navigation-previous"
-        on:click={navNext}
-      >
-        <span><i class="fas fa-chevron-down" /></span>
-      </div>
-    {/if}
-  </div>
+      {#if $activeOnboardingStage && $showOnboardingNavigation}
+        <div
+          id="navigation-next"
+          style="--bottom-height: {nextHeight}"
+          class="visahoi-navigation-next"
+          on:click={navPrev}
+        >
+          <span><i class="fas fa-chevron-up" /></span>
+        </div>
+        <div
+          id="navigation-previous"
+          style="--bottom-height: {prevHeight}"
+          class="visahoi-navigation-previous"
+          on:click={navNext}
+        >
+          <span><i class="fas fa-chevron-down" /></span>
+        </div>
+      {/if}
+    </div>
+  {/key}
 
   {#each $onboardingStages.sort((a, b) => a.order - b.order) as stage, index}
     <OnboardingNavigationItem {stage} {index} />

--- a/packages/core/src/components/OnboardingNavigation.svelte
+++ b/packages/core/src/components/OnboardingNavigation.svelte
@@ -25,22 +25,22 @@
     switch ($markerIndexId) {
       case 0: {
         await tick();
-        const preElementId = document.getElementById("navigation-previous");
+        const preElementId = document.getElementById("navigation-next");
         preElementId?.style.pointerEvents = "none";
         preElementId?.style.opacity = 0.5;
 
-        const nextElementId = document.getElementById("navigation-next");
+        const nextElementId = document.getElementById("navigation-previous");
         nextElementId?.style.pointerEvents = "all";
         nextElementId?.style.opacity = 1;
         break;
       }
       case $markerInformation.length - 1: {
         await tick();
-        const nextElementId = document.getElementById("navigation-next");
+        const nextElementId = document.getElementById("navigation-previous");
         nextElementId?.style.pointerEvents = "none";
         nextElementId?.style.opacity = 0.5;
 
-        const preElementId = document.getElementById("navigation-previous");
+        const preElementId = document.getElementById("navigation-next");
         preElementId?.style.pointerEvents = "all";
         preElementId?.style.opacity = 1;
         break;
@@ -65,7 +65,7 @@
       const elementId = getNavigationMarkerDomId($previousMarkerId);
       document.getElementById(elementId)?.style.opacity = 0.5;
     }
-    const elementId = document.getElementById("navigation-previous");
+    const elementId = document.getElementById("navigation-next");
     elementId?.style.pointerEvents = "all";
     elementId?.style.opacity = 1;
 
@@ -74,7 +74,7 @@
         if (marker.marker.id === $selectedMarker.marker.id) {
           index = i + 1;
           if (index + 1 === $markerInformation.length) {
-            const elementId = document.getElementById("navigation-next");
+            const elementId = document.getElementById("navigation-previous");
             elementId?.style.pointerEvents = "none";
             elementId?.style.opacity = 0.5;
           }
@@ -98,7 +98,7 @@
       const elementId = getNavigationMarkerDomId($previousMarkerId);
       document.getElementById(elementId)?.style.opacity = 0.5;
     }
-    const elementId = document.getElementById("navigation-next");
+    const elementId = document.getElementById("navigation-previous");
     elementId?.style.pointerEvents = "all";
     elementId?.style.opacity = 1;
 
@@ -106,8 +106,9 @@
       $markerInformation.map((marker, i) => {
         if (marker.marker.id === $selectedMarker.marker.id) {
           index = i - 1;
+
           if (index === 0) {
-            const elementId = document.getElementById("navigation-previous");
+            const elementId = document.getElementById("navigation-next");
             elementId?.style.pointerEvents = "none";
             elementId?.style.opacity = 0.5;
           }
@@ -134,8 +135,20 @@
   style="--flexDirection:{$navigationAlignment}; height: '60px' "
 >
   <div class="visahoi-navigation-marker-container">
-    {#if $activeOnboardingStage && $showOnboardingNavigation}
+    <!-- {#if $activeOnboardingStage && $showOnboardingNavigation}
       {#each $markerInformation.sort( (a, b) => (a.message.onboardingStage.title < b.message.onboardingStage.title ? -1 : a.message.onboardingStage.title > b.message.onboardingStage.title ? 1 : 0) ) as marker, index}
+        <NavigationMarker markerInformation={marker} order={index + 1} />
+      {/each}
+    {/if} -->
+
+    {#if $activeOnboardingStage && $showOnboardingNavigation}
+      {#each $markerInformation.sort((a, b) => {
+        if (a.message.onboardingStage.title === b.message.onboardingStage.title) {
+          return a.message?.order < b.message?.order ? -1 : 1;
+        } else {
+          return a.message.onboardingStage.title > b.message.onboardingStage.title ? -1 : 1;
+        }
+      }) as marker, index}
         <NavigationMarker markerInformation={marker} order={index + 1} />
       {/each}
     {/if}
@@ -145,7 +158,7 @@
         id="navigation-next"
         style="--bottom-height: {nextHeight}"
         class="visahoi-navigation-next"
-        on:click={navNext}
+        on:click={navPrev}
       >
         <span><i class="fas fa-chevron-up" /></span>
       </div>
@@ -153,7 +166,7 @@
         id="navigation-previous"
         style="--bottom-height: {prevHeight}"
         class="visahoi-navigation-previous"
-        on:click={navPrev}
+        on:click={navNext}
       >
         <span><i class="fas fa-chevron-down" /></span>
       </div>
@@ -176,7 +189,8 @@
     cursor: pointer;
     transition: opacity 0.5s ease, bottom 0.5s ease;
     width: 80px;
-    bottom: 20px;
+    /* bottom: 20px; */
+    bottom: 80px;
     opacity: 1;
     z-index: 15;
   }

--- a/packages/core/src/components/OnboardingUI.svelte
+++ b/packages/core/src/components/OnboardingUI.svelte
@@ -32,6 +32,7 @@
 
   const setMarkerInformation = () => {
     const updatedMarkerInformation = getMarkerInformation($onboardingMessages);
+
     markerInformation.set(updatedMarkerInformation);
     // update data of active marker
     activeMarker.set(

--- a/packages/core/src/components/Tooltip.svelte
+++ b/packages/core/src/components/Tooltip.svelte
@@ -16,6 +16,7 @@
   import { getMarkerDomId } from "../utils";
   import { onDestroy, onMount, tick } from "svelte";
   import { getOnboardingMessages } from "../onboarding";
+  import { get } from "svelte/store";
 
   export let visElement;
 
@@ -85,18 +86,6 @@
         markerInformation.set(tempMarkerInformation);
 
         // check whether the onboarding message deleted is the last message of the activeOboarding stage.
-        // If it is then show all the onboarding stages.
-        // $onboardingStages.map((o, i) => {
-        //   const res = $markerInformation.find(
-        //     (m) => m.message.onboardingStage.id === o.id
-        //   );
-        //   if (res === undefined) {
-        //     const tempOnboardinStages = $onboardingStages;
-        //     tempOnboardinStages.splice(i, 1);
-        //     onboardingStages.set(tempOnboardinStages);
-        //     activeOnboardingStage.set(null);
-        //   }
-        // });
 
         const result = $markerInformation.find(
           (m) => m.message.onboardingStage.id === $activeOnboardingStage?.id
@@ -121,7 +110,6 @@
         const tempOnboardingMessage = $onboardingMessages;
         tempOnboardingMessage.splice(i, 1);
         onboardingMessages.set(tempOnboardingMessage);
-        // console.log(getOnboardingMessages(), "onboarding message");
       }
     });
 

--- a/packages/core/src/heatmap.ts
+++ b/packages/core/src/heatmap.ts
@@ -40,6 +40,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-1",
       },
+      order: 1,
     },
     {
       anchor: getAnchor(spec.heatmapDescription, visElement),
@@ -50,6 +51,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-2",
       },
+      order: 2,
     },
     {
       anchor: getAnchor(spec.legendDescription, visElement),
@@ -60,6 +62,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-3",
       },
+      order: 3,
     },
     {
       anchor: getAnchor(spec.axisDescription, visElement),
@@ -70,6 +73,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-4",
       },
+      order: 4,
     },
     {
       anchor: getAnchor(spec.hoverDescription, visElement),
@@ -80,6 +84,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-5",
       },
+      order: 1,
     },
   ];
 

--- a/packages/core/src/horizon-graph.ts
+++ b/packages/core/src/horizon-graph.ts
@@ -42,6 +42,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-2",
       },
+      order: 2,
     },
     {
       anchor: getAnchor(spec.xAxis, visElement),
@@ -52,6 +53,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-3",
       },
+      order: 3,
     },
     {
       anchor: getAnchor(spec.positiveColor, visElement),
@@ -67,6 +69,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-4",
       },
+      order: 4,
     },
     {
       anchor: getAnchor(spec.negativeColor, visElement),
@@ -79,6 +82,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-5",
       },
+      order: 5,
     },
     {
       anchor: spec.yMin?.anchor,
@@ -89,6 +93,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-6",
       },
+      order: 6,
     },
     {
       anchor: spec.yMax?.anchor,
@@ -99,6 +104,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-7",
       },
+      order: 7,
     },
   ];
 
@@ -112,6 +118,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-1",
       },
+      order: 1,
     });
   }
 

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -89,6 +89,7 @@ export interface IOnboardingMessage {
   onboardingStage: IOnboardingStage;
   tooltipPosition?: TooltipPosition;
   marker: IMarker;
+  order?: number;
 }
 
 export enum EDefaultOnboardingStages {

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -8,7 +8,6 @@ import {
   showHideCloseText,
   showOnboardingNavigation,
   isEditModeActive,
-  activeOnboardingStage,
 } from "./components/stores.js";
 import debounce from "lodash.debounce";
 import {

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -43,6 +43,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-2",
       },
+      order: 1,
     },
     {
       anchor: getAnchor(spec.legendTitle, visElement),
@@ -53,6 +54,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-3",
       },
+      order: 1,
     },
     {
       anchor: getAnchor(spec.xAxisTitle, visElement),
@@ -63,6 +65,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-4",
       },
+      order: 2,
     },
     {
       anchor: getAnchor(spec.yAxisTitle, visElement),
@@ -73,6 +76,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-5",
       },
+      order: 2,
     },
     {
       anchor: getAnchor(spec.maxValue, visElement),
@@ -83,6 +87,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-6",
       },
+      order: 3,
     },
   ];
 
@@ -96,6 +101,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-1",
       },
+      order: 1,
     });
   }
 

--- a/packages/core/src/treemap.ts
+++ b/packages/core/src/treemap.ts
@@ -35,6 +35,8 @@ function generateMessages(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
 
+  console.log("test");
+
   const messages: IOnboardingMessage[] = [
     {
       anchor: getAnchor(spec.desc, visElement),
@@ -45,6 +47,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-2",
       },
+      order: 1,
     },
     {
       anchor: getAnchor(spec.subDesc, visElement),
@@ -55,6 +58,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-3",
       },
+      order: 3,
     },
     {
       anchor: getAnchor(spec.otherDesc, visElement),
@@ -65,6 +69,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-4",
       },
+      order: 4,
     },
     {
       anchor: getAnchor(spec.gapDesc, visElement),
@@ -75,6 +80,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-5",
       },
+      order: 5,
     },
 
     {
@@ -121,6 +127,7 @@ function generateMessages(
       marker: {
         id: "unique-marker-id-1",
       },
+      order: 2,
     });
   }
 

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -7,6 +7,8 @@ import {
   setOnboardingStage,
   getOnboardingMessages,
   setEditMode,
+  createBasicOnboardingStage,
+  createBasicOnboardingMessage,
 } from '@visahoi/plotly';
 import debounce from 'lodash.debounce';
 
@@ -70,6 +72,7 @@ const getAhoiConfig = () => {
     EVisualizationType.SCATTERPLOT,
     chart,
   );
+
   const extendedOnboardingMessages = defaultOnboardingMessages.map(
     (message) => ({
       ...message,


### PR DESCRIPTION
closes #149 
Summary:
* Add order to onboarding messages
*  Changed the ordering navigation marker

screenshot:
![image](https://user-images.githubusercontent.com/104566246/187894189-a61912b8-3f17-42e5-94a5-426f002cfc9b.png)
