### PR TITLE
Tooltips can have icons

### DIFF
--- a/packages/core/src/components/Tooltip.svelte
+++ b/packages/core/src/components/Tooltip.svelte
@@ -237,11 +237,12 @@
   {#if $editTooltip}
     <textarea class="visahoi-tooltip-textarea" rows="4" bind:value={tempText} />
   {:else}
+    <!-- <div id="tooltip-text" class="visahoi-tooltip-content">
+      {@html sanitizeHtml(textString, sanitizerOptions)}
+    </div> -->
+
     <div class="visahoi-tooltip-content">
-      {@html sanitizeHtml(
-        activeMarkerInformation?.tooltip.text,
-        sanitizerOptions
-      )}
+      {@html activeMarkerInformation?.tooltip.text}
     </div>
   {/if}
 

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -132,7 +132,7 @@ const registerEventListener = () => {
     setOnboardingMessage({
       id: 'unique-message-id-6',
       title: 'test-1',
-      text: 'testing....'
+      text: '<i class="fas fa-question-circle"></i> test'
     })
   })
 


### PR DESCRIPTION
closes #186 
Summary: 
* Tooltip text can include icons.

screenshot:
![image](https://user-images.githubusercontent.com/104566246/195047536-99f970f0-616c-43c5-93c4-500653879f79.png)
