### PR TITLE
Sgeo/183 add canvas support for plotly scatterplot

### DIFF
--- a/packages/core/src/components/OnboardingNavigationMainItem.svelte
+++ b/packages/core/src/components/OnboardingNavigationMainItem.svelte
@@ -90,7 +90,7 @@
   </span>
 </div>
 
-<div class="toggle-button">
+<!-- <div class="toggle-button">
   {#if $showOnboardingNavigation}
     <span title="Disable navigation steps" on:click={toggleNavigation}>
       <i class="fas fa-solid fa-toggle-on" />
@@ -104,8 +104,7 @@
       />
     </span>
   {/if}
-</div>
-
+</div> -->
 <style>
   .toggle-button {
     position: absolute;

--- a/packages/core/src/components/OnboardingUI.svelte
+++ b/packages/core/src/components/OnboardingUI.svelte
@@ -23,6 +23,8 @@
   export let ref;
   export let visElement: Element;
 
+  $: console.log(visElement, "Visualization element");
+
   const setVisElementPosition = () => {
     visXPosition.set(visElement.getBoundingClientRect().x);
     visYPosition.set(visElement.getBoundingClientRect().y);

--- a/packages/core/src/components/OnboardingUI.svelte
+++ b/packages/core/src/components/OnboardingUI.svelte
@@ -26,6 +26,7 @@
   $: console.log(visElement, "Visualization element");
 
   const setVisElementPosition = () => {
+    console.log(visElement.getBoundingClientRect().x, "X pos");
     visXPosition.set(visElement.getBoundingClientRect().x);
     visYPosition.set(visElement.getBoundingClientRect().y);
     visWidth.set(visElement.clientWidth);
@@ -73,7 +74,7 @@
 >
   <Markers />
   <Tooltips {visElement} />
-  <OnboardingNavigation height={$visHeight} />
+  <OnboardingNavigation height={$visHeight} top="" />
   {#if $activeOnboardingStage && $showBackdrop}
     <Backdrop />
   {/if}

--- a/packages/core/src/components/OnboardingUI.svelte
+++ b/packages/core/src/components/OnboardingUI.svelte
@@ -70,11 +70,11 @@
   style="width:{$visWidth + 'px'}; height:{$visHeight +
     'px'}; top:{$visYPosition + window.scrollY + 'px'}; left:{$visXPosition +
     window.scrollX +
-    'px'} position: absolute"
+    'px'}; position: 'absolute'"
 >
   <Markers />
   <Tooltips {visElement} />
-  <OnboardingNavigation height={$visHeight} top="" />
+  <OnboardingNavigation height={$visHeight} />
   {#if $activeOnboardingStage && $showBackdrop}
     <Backdrop />
   {/if}

--- a/packages/core/src/components/OnboardingUI.svelte
+++ b/packages/core/src/components/OnboardingUI.svelte
@@ -23,10 +23,7 @@
   export let ref;
   export let visElement: Element;
 
-  $: console.log(visElement, "Visualization element");
-
   const setVisElementPosition = () => {
-    console.log(visElement.getBoundingClientRect().x, "X pos");
     visXPosition.set(visElement.getBoundingClientRect().x);
     visYPosition.set(visElement.getBoundingClientRect().y);
     visWidth.set(visElement.clientWidth);

--- a/packages/core/src/components/Tooltip.svelte
+++ b/packages/core/src/components/Tooltip.svelte
@@ -13,7 +13,6 @@
   import { v4 as uuidv4 } from "uuid";
   import { IMarkerInformation, TooltipPosition } from "../interfaces";
   import { createPopper } from "@popperjs/core/dist/esm/";
-  import sanitizeHtml from "sanitize-html";
   import { getMarkerDomId } from "../utils";
   import { tick } from "svelte";
 
@@ -21,13 +20,6 @@
 
   let tempTitle = "";
   let tempText = "";
-
-  const sanitizerOptions = {
-    allowedTags: ["span", "b", "em", "strong"],
-    allowedClasses: {
-      span: ["visahoi-tooltip-hover-text"],
-    },
-  };
 
   let activeMarkerInformation: IMarkerInformation | null = null;
 
@@ -238,10 +230,7 @@
     <textarea class="visahoi-tooltip-textarea" rows="4" bind:value={tempText} />
   {:else}
     <div class="visahoi-tooltip-content">
-      {@html sanitizeHtml(
-        activeMarkerInformation?.tooltip.text,
-        sanitizerOptions
-      )}
+      {@html activeMarkerInformation?.tooltip.text}
     </div>
   {/if}
 

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -68,9 +68,9 @@ export interface IBackdropConfig {
 
 export interface IAhoiConfig {
   onboardingMessages: IOnboardingMessage[];
-  backdrop: IBackdropConfig;
+  backdrop?: IBackdropConfig;
   showHelpCloseText?: boolean;
-  showOnboardingNavigation: boolean;
+  showOnboardingNavigation?: boolean;
 }
 
 export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -81,7 +81,7 @@ function generateMessages (
         id: 'unique-marker-id-5'
       },
       id: 'unique-message-id-5',
-      order: 2
+      order: 3
     },
     {
       anchor: getAnchor(spec.maxValue, visElement),
@@ -93,8 +93,7 @@ function generateMessages (
         id: 'unique-marker-id-6'
       },
       id: 'unique-message-id-6',
-      order: 3
-    }
+      order: 4
   ]
 
   if (spec.chartTitle?.value !== undefined) {
@@ -123,7 +122,7 @@ function generateMessages (
         id: 'unique-marker-id-3'
       },
       id: 'unique-message-id-3',
-      order: 2
+      order: 5
     })
   }
 

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -61,9 +61,9 @@ function generateMessages (
     {
       anchor: getAnchor(spec.xAxisTitle, visElement),
       requires: ['xAxisTitle', 'yAxisTitle'],
-      text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
+      text: `The columns show the ${spec.xAxisTitle?.value}, while the rows show the ${spec.yAxisTitle?.value}.`,
       title: 'Reading the chart',
-      onboardingStage: analyzing,
+      onboardingStage: reading,
       marker: {
         id: 'unique-marker-id-4'
       },
@@ -75,7 +75,7 @@ function generateMessages (
       requires: ['yAxisTitle', 'xAxisTitle'],
       text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
       title: 'Interacting with the chart',
-      onboardingStage: interacting,
+      onboardingStage: reading,
       marker: {
         id: 'unique-marker-id-5'
       },

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -47,18 +47,6 @@ function generateMessages (
       id: 'unique-message-id-2',
       order: 1
     },
-    // {
-    //   anchor: getAnchor(spec.legendTitle, visElement),
-    //   requires: ['legendTitle'],
-    //   text: 'It shows different traces',
-    //   title: 'Reading the chart',
-    //   onboardingStage: reading,
-    //   marker: {
-    //     id: 'unique-marker-id-3'
-    //   },
-    //   id: 'unique-message-id-3',
-    //   order: 2
-    // },
     {
       anchor: getAnchor(spec.xAxisTitle, visElement),
       requires: ['xAxisTitle', 'yAxisTitle'],

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -47,18 +47,18 @@ function generateMessages (
       id: 'unique-message-id-2',
       order: 1
     },
-    {
-      anchor: getAnchor(spec.legendTitle, visElement),
-      requires: ['legendTitle'],
-      text: 'It shows different traces',
-      title: 'Reading the chart',
-      onboardingStage: reading,
-      marker: {
-        id: 'unique-marker-id-3'
-      },
-      id: 'unique-message-id-3',
-      order: 1
-    },
+    // {
+    //   anchor: getAnchor(spec.legendTitle, visElement),
+    //   requires: ['legendTitle'],
+    //   text: 'It shows different traces',
+    //   title: 'Reading the chart',
+    //   onboardingStage: reading,
+    //   marker: {
+    //     id: 'unique-marker-id-3'
+    //   },
+    //   id: 'unique-message-id-3',
+    //   order: 2
+    // },
     {
       anchor: getAnchor(spec.xAxisTitle, visElement),
       requires: ['xAxisTitle', 'yAxisTitle'],
@@ -109,6 +109,21 @@ function generateMessages (
       },
       id: 'unique-message-id-1',
       order: 1
+    })
+  }
+
+  if (spec.legendTitle?.value !== undefined) {
+    messages.unshift({
+      anchor: getAnchor(spec.legendTitle, visElement),
+      requires: ['legendTitle'],
+      text: 'It shows different traces',
+      title: 'Reading the chart',
+      onboardingStage: reading,
+      marker: {
+        id: 'unique-marker-id-3'
+      },
+      id: 'unique-message-id-3',
+      order: 2
     })
   }
 

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -94,22 +94,8 @@ function generateMessages (
       },
       id: 'unique-message-id-6',
       order: 4
+    }
   ]
-
-  if (spec.chartTitle?.value !== undefined) {
-    messages.unshift({
-      anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ['chartTitle', 'title'],
-      text: `The chart shows the ${spec.title?.value}.`,
-      title: 'Reading the chart',
-      onboardingStage: reading,
-      marker: {
-        id: 'unique-marker-id-1'
-      },
-      id: 'unique-message-id-1',
-      order: 1
-    })
-  }
 
   if (spec.legendTitle?.value !== undefined) {
     messages.unshift({
@@ -123,6 +109,21 @@ function generateMessages (
       },
       id: 'unique-message-id-3',
       order: 5
+    })
+  }
+
+  if (spec.chartTitle?.value !== undefined) {
+    messages.unshift({
+      anchor: getAnchor(spec.chartTitle, visElement),
+      requires: ['chartTitle', 'title'],
+      text: `The chart shows the ${spec.title?.value}.`,
+      title: 'Reading the chart',
+      onboardingStage: reading,
+      marker: {
+        id: 'unique-marker-id-1'
+      },
+      id: 'unique-message-id-1',
+      order: 1
     })
   }
 

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -97,7 +97,7 @@ function generateMessages (
     }
   ]
 
-  if (spec.legendTitle?.value !== undefined) {
+  if (spec.legendTitle?.value !== '') {
     messages.unshift({
       anchor: getAnchor(spec.legendTitle, visElement),
       requires: ['legendTitle'],

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -69,7 +69,7 @@ function generateMessages (
         id: 'unique-marker-id-4'
       },
       id: 'unique-message-id-4',
-      order: 2
+      order: 3
     },
     {
       anchor: getAnchor(spec.yAxisTitle, visElement),
@@ -81,7 +81,7 @@ function generateMessages (
         id: 'unique-marker-id-5'
       },
       id: 'unique-message-id-5',
-      order: 3
+      order: 4
     },
     {
       anchor: getAnchor(spec.maxValue, visElement),
@@ -93,7 +93,7 @@ function generateMessages (
         id: 'unique-marker-id-6'
       },
       id: 'unique-message-id-6',
-      order: 4
+      order: 5
     }
   ]
 
@@ -108,7 +108,7 @@ function generateMessages (
         id: 'unique-marker-id-3'
       },
       id: 'unique-message-id-3',
-      order: 5
+      order: 2
     })
   }
 

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -46,19 +46,19 @@ function generateMessages (
       },
       id: 'unique-message-id-4',
       order: 3
-    },
-    {
-      anchor: getAnchor(spec.yAxisTitle, visElement),
-      requires: ['yAxisTitle', 'xAxisTitle'],
-      text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-      title: 'Interacting with the chart',
-      onboardingStage: reading,
-      marker: {
-        id: 'unique-marker-id-5'
-      },
-      id: 'unique-message-id-5',
-      order: 4
     }
+    // {
+    //   anchor: getAnchor(spec.yAxisTitle, visElement),
+    //   requires: ['yAxisTitle', 'xAxisTitle'],
+    //   text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
+    //   title: 'Interacting with the chart',
+    //   onboardingStage: reading,
+    //   marker: {
+    //     id: 'unique-marker-id-5'
+    //   },
+    //   id: 'unique-message-id-5',
+    //   order: 4
+    // }
   ]
   if (spec.type?.value !== undefined) {
     messages.unshift({

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -36,18 +36,6 @@ function generateMessages (
 
   const messages: IOnboardingMessage[] = [
     {
-      anchor: getAnchor(spec.type, visElement),
-      requires: ['type'],
-      text: `The chart Is based on colored ${spec.type?.value} elements.`,
-      title: 'Interacting with the chart',
-      onboardingStage: interacting,
-      marker: {
-        id: 'unique-marker-id-2'
-      },
-      id: 'unique-message-id-2',
-      order: 1
-    },
-    {
       anchor: getAnchor(spec.xAxisTitle, visElement),
       requires: ['xAxisTitle', 'yAxisTitle'],
       text: `The columns show the ${spec.xAxisTitle?.value}, while the rows show the ${spec.yAxisTitle?.value}.`,
@@ -70,8 +58,25 @@ function generateMessages (
       },
       id: 'unique-message-id-5',
       order: 4
-    },
-    {
+    }
+  ]
+  if (spec.type?.value !== undefined) {
+    messages.unshift({
+      anchor: getAnchor(spec.type, visElement),
+      requires: ['type'],
+      text: `The chart Is based on colored ${spec.type?.value} elements.`,
+      title: 'Interacting with the chart',
+      onboardingStage: interacting,
+      marker: {
+        id: 'unique-marker-id-2'
+      },
+      id: 'unique-message-id-2',
+      order: 1
+    })
+  }
+
+  if (spec.maxValue?.value !== undefined) {
+    messages.unshift({
       anchor: getAnchor(spec.maxValue, visElement),
       requires: ['maxValue'],
       text: `The chart Is based on colored ${spec.type?.value} elements.`,
@@ -82,8 +87,8 @@ function generateMessages (
       },
       id: 'unique-message-id-6',
       order: 5
-    }
-  ]
+    })
+  }
 
   if (spec.legendTitle?.value !== '') {
     messages.unshift({

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -10,6 +10,7 @@ import { getAnchor } from './utils'
 
 export interface IOnboardingScatterplotSpec extends IOnboardingSpec {
   chartTitle?: ISpecProp;
+  title?: ISpecProp;
   type?: ISpecProp;
   legendTitle?: ISpecProp;
   xAxis?: ISpecProp;
@@ -99,8 +100,8 @@ function generateMessages (
   if (spec.chartTitle?.value !== undefined) {
     messages.unshift({
       anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ['chartTitle'],
-      text: `The chart shows the ${spec.chartTitle?.value}.`,
+      requires: ['chartTitle', 'title'],
+      text: `The chart shows the ${spec.title?.value}.`,
       title: 'Reading the chart',
       onboardingStage: reading,
       marker: {

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -49,7 +49,7 @@ function generateMessages (
     {
       anchor: getAnchor(spec.legendTitle, visElement),
       requires: ['legendTitle'],
-      text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
+      text: 'It shows different traces',
       title: 'Reading the chart',
       onboardingStage: reading,
       marker: {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -19,9 +19,9 @@ const getDomNodeByTextContent = (
       NodeFilter.SHOW_TEXT, // Look for text nodes only
       {
         acceptNode (node) {
-          console.log(NodeFilter, 'node filter')
-          console.log(node.textContent, 'Node text content ')
-          console.log(new RegExp(textContent), 'RegExp text content')
+          // console.log(NodeFilter, 'node filter')
+          // console.log(node.textContent, 'Node text content ')
+          // console.log(new RegExp(textContent), 'RegExp text content1')
 
           // The filter method of interface NodeFilter
           return new RegExp(textContent).test(node.textContent as string) // Check if text contains target string
@@ -45,8 +45,6 @@ export const getAnchor = (
     // if prop is undefined -> return
 
   } else if (prop.anchor?.findDomNodeByValue) {
-    // eslint-disable-next-line no-debugger
-    debugger
     // the dom node should be found by it's content
     // TODO: can findDomNodeByValue be removed?
     const targetDomNode = getDomNodeByTextContent(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -41,6 +41,8 @@ export const getAnchor = (
     // if prop is undefined -> return
 
   } else if (prop.anchor?.findDomNodeByValue) {
+    // eslint-disable-next-line no-debugger
+    debugger
     // the dom node should be found by it's content
     // TODO: can findDomNodeByValue be removed?
     const targetDomNode = getDomNodeByTextContent(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -19,11 +19,6 @@ const getDomNodeByTextContent = (
       NodeFilter.SHOW_TEXT, // Look for text nodes only
       {
         acceptNode (node) {
-          // console.log(NodeFilter, 'node filter')
-          // console.log(node.textContent, 'Node text content ')
-          // console.log(new RegExp(textContent), 'RegExp text content1')
-
-          // The filter method of interface NodeFilter
           return new RegExp(textContent).test(node.textContent as string) // Check if text contains target string
             ? NodeFilter.FILTER_ACCEPT // Found: accept node
             : NodeFilter.FILTER_REJECT // Not found: reject and continue

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -19,6 +19,10 @@ const getDomNodeByTextContent = (
       NodeFilter.SHOW_TEXT, // Look for text nodes only
       {
         acceptNode (node) {
+          console.log(NodeFilter, 'node filter')
+          console.log(node.textContent, 'Node text content ')
+          console.log(new RegExp(textContent), 'RegExp text content')
+
           // The filter method of interface NodeFilter
           return new RegExp(textContent).test(node.textContent as string) // Check if text contains target string
             ? NodeFilter.FILTER_ACCEPT // Found: accept node

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -3,14 +3,9 @@ import {
   generateBasicAnnotations,
   ahoi,
   EVisualizationType,
-  deleteOnboardingStage,
   setOnboardingStage,
   setOnboardingMessage,
-  getOnboardingMessages,
-  setEditMode,
-  createBasicOnboardingStage,
-  createBasicOnboardingMessage,
-  getOnboardingStages
+  setEditMode
 } from '@visahoi/plotly'
 import debounce from 'lodash.debounce'
 
@@ -138,7 +133,7 @@ const registerEventListener = () => {
     setOnboardingMessage({
       id: 'unique-message-id-6',
       title: 'test-1',
-      text: 'testing....'
+      text: '<i class="fas fa-question-circle"></i> test'
     })
   })
 

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -54,6 +54,7 @@ function makePlotly (x, y) {
 
   const layout = {
     title: 'Some title of cars or something',
+    showlegend: true,
     xaxis: {
       title: 'Horsepower'
     },

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -53,7 +53,7 @@ function makePlotly (x, y) {
   ]
 
   const layout = {
-    title: 'Some title of cars or something',
+    title: 'Some title of cars or something (test)',
     showlegend: true,
     xaxis: {
       title: 'Horsepower'

--- a/packages/plotly/src/heatmap.ts
+++ b/packages/plotly/src/heatmap.ts
@@ -16,7 +16,7 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       value: chart.layout.title.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: { left: -40, top: -10 }
+        offset: { left: -40, top: -20 }
       }
     },
     heatmapDescription: {

--- a/packages/plotly/src/heatmap.ts
+++ b/packages/plotly/src/heatmap.ts
@@ -16,14 +16,14 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       value: chart.layout.title.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: { left: -20, top: 10 }
+        offset: { left: -40, top: -10 }
       }
     },
     heatmapDescription: {
       value: t.type,
       anchor: {
         sel: '.heatmaplayer > .hm > image',
-        offset: { left: -50, top: -30 }
+        offset: { left: -50, top: -40 }
       }
     },
     legendDescription: {
@@ -50,7 +50,7 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       value: t?.xaxis?.title?.text,
       anchor: {
         sel: '.cartesianlayer',
-        offset: { top: -50, left: -120 }
+        offset: { left: -120, top: -90 }
       }
     }
   }

--- a/packages/plotly/src/heatmap.ts
+++ b/packages/plotly/src/heatmap.ts
@@ -41,10 +41,10 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       }
     },
     xAxis: {
-      value: chart.layout?.xaxis?.title.text
+      value: chart.layout?.xaxis?.title?.text
     },
     yAxis: {
-      value: chart.layout?.yaxis?.title.text
+      value: chart.layout?.yaxis?.title?.text
     },
     hoverDescription: {
       value: t?.xaxis?.title?.text,

--- a/packages/plotly/src/heatmap.ts
+++ b/packages/plotly/src/heatmap.ts
@@ -41,10 +41,10 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       }
     },
     xAxis: {
-      value: chart.layout.xaxis.title.text
+      value: chart.layout?.xaxis?.title.text
     },
     yAxis: {
-      value: chart.layout.yaxis.title.text
+      value: chart.layout?.yaxis?.title.text
     },
     hoverDescription: {
       value: t?.xaxis?.title?.text,

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -21,7 +21,7 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       value: (newTitle !== '') ? newTitle : title,
       anchor: {
         findDomNodeByValue: true,
-        offset: { left: -20, top: 10 }
+        offset: { left: -20, top: -10 }
       }
     },
     title: {

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -54,8 +54,6 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
   // const maxY = yVals[maxXIndex]
   const title = chart?.layout?.title?.text
   let newTitle = ''
-  // eslint-disable-next-line no-debugger
-  debugger
   if (title.includes('(')) {
     const id = title.indexOf('(')
     newTitle = title.substring(0, id)

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -6,14 +6,6 @@ import {
 import { IOnboardingScatterplotSpec } from '@visahoi/core/src/scatterplot'
 
 function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec {
-  // const traceData = (<any>(
-  //   Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
-  // ))?.__data__
-
-  // const ss = (<any>(
-  //   Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
-  // ))
-
   const title = chart?.layout?.title?.text
   const legend = chart.data[0]?.marker?.colorbar?.title?.text
   let newTitle = ''
@@ -37,26 +29,16 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
     title: {
       value: title
     },
-    // type: {
-    //   value: t.type,
-    //   anchor: {
-    //     sel: '.points > .point:nth-child(4)'
-    //   }
-    // },
     xAxisTitle: {
       value: chart.layout.xaxis?.title.text,
       anchor: {
-        // sel: '.infolayer .xtitle',
         findDomNodeByValue: true
-        // offset: { left: -20 }
       }
     },
     yAxisTitle: {
       value: chart.layout.yaxis?.title.text,
       anchor: {
-        // sel: '.infolayer .ytitle',
         findDomNodeByValue: true
-        // offset: { top: -25 }
       }
     },
     legendTitle: {
@@ -67,13 +49,6 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       }
     }
   }
-  // maxValue: {
-  //   value: maxX,
-  //   anchor: {
-  //     coords: { x: maxX, y: maxY },
-  //     offset: { left: 25 }
-  //   }
-  // }
 }
 
 export function scatterplotFactory (

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -6,52 +6,10 @@ import {
 import { IOnboardingScatterplotSpec } from '@visahoi/core/src/scatterplot'
 
 function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec {
-  // console.log(chart, 'chart data')
-  // console.log(chart.layout)
-  const traceData = (<any>(
-    Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
-  ))?.__data__
+  // const traceData = (<any>(
+  //   Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
+  // ))?.__data__
 
-  // const traceNodes = chart.querySelectorAll('g.points')
-  // if (traceNodes === undefined || traceNodes === null) {
-  //   console.error(
-  //     'Error: The trace is null or undefined, therefore not all onboarding messages can be shown.'
-  //   )
-  //   return {
-  //     chartTitle: {
-  //       value: chart?.layout?.title?.text,
-  //       anchor: {
-  //         findDomNodeByValue: true,
-  //         offset: { left: -20, top: 10 }
-  //       }
-  //     }
-  //   }
-  // }
-
-  // const areaNodes = traceNodes[0]?.querySelectorAll('path.point')
-  // const areaNodesData = Array.from(areaNodes).map(
-  //   (point: any) => point.__data__
-  // )
-  // const t = areaNodesData[0].trace
-
-  // const grid = document
-  //   .getElementsByClassName('nsewdrag drag')[0]
-  //   .getBoundingClientRect()
-
-  // const points = (Array.from(areaNodes) as any[]).filter(
-  //   (point) =>
-  //     point.getBoundingClientRect().x &&
-  //     point.getBoundingClientRect().x <= grid.width + grid.x &&
-  //     point.getBoundingClientRect().y &&
-  //     point.getBoundingClientRect().y <= grid.height + grid.y
-  // )
-
-  // const xVals = points.map((point) => point.getBoundingClientRect().x)
-  // const yVals = points.map((point) => point.getBoundingClientRect().y)
-
-  // const maxX = Math.max(...xVals)
-  // const maxXIndex = xVals.indexOf(maxX)
-  // const maxY = yVals[maxXIndex]
   const title = chart?.layout?.title?.text
   let newTitle = ''
   if (title.includes('(')) {

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -48,14 +48,14 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
         findDomNodeByValue: true
         // offset: { top: -25 }
       }
+    },
+    legendTitle: {
+      value: chart.data?.marker?.colorbar?.title?.text,
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { top: 20 }
+      }
     }
-    // legendTitle: {
-    //   value: traceData[3]?.trace?.name,
-    //   anchor: {
-    //     findDomNodeByValue: true,
-    //     offset: { top: 20 }
-    //   }
-    // }
   }
   // maxValue: {
   //   value: maxX,

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -14,11 +14,11 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
   const legend = chart.data[0]?.marker?.colorbar?.title?.text
   let newTitle = ''
   let newLegend = ''
-  if (title.includes('(')) {
+  if (title?.includes('(')) {
     const id = title.indexOf('(')
     newTitle = title.substring(0, id)
   }
-  if (legend.includes('<')) {
+  if (legend?.includes('<')) {
     const id = legend.indexOf('<')
     newLegend = legend.substring(0, id)
   }

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -6,9 +6,10 @@ import {
 import { IOnboardingScatterplotSpec } from '@visahoi/core/src/scatterplot'
 
 function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec {
-  // const traceData = (<any>(
-  //   Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
-  // ))?.__data__
+  const traceData = (<any>(
+    Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
+  ))?.__data__
+  console.log(traceData, 'Trace - Data')
 
   const title = chart?.layout?.title?.text
   const legend = chart.data[0]?.marker?.colorbar?.title?.text

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -7,6 +7,12 @@ import { IOnboardingScatterplotSpec } from '@visahoi/core/src/scatterplot'
 
 function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec {
   console.log(chart, 'chart data')
+  console.log(chart.layout)
+  const traceData = (<any>(
+    Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
+  )).__data__
+
+  console.log(traceData[0]?.trace?.name, 'legend name')
   // const traceNodes = chart.querySelectorAll('g.points')
   // if (traceNodes === undefined || traceNodes === null) {
   //   console.error(
@@ -76,6 +82,14 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
         // sel: '.infolayer .ytitle',
         findDomNodeByValue: true
         // offset: { top: -25 }
+      }
+    },
+    legendTitle: {
+      value: traceData[0]?.trace?.name,
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { top: 20 }
+      }
       }
     }
     // maxValue: {

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -9,6 +9,11 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
   const traceData = (<any>(
     Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
   ))?.__data__
+
+  const ss = (<any>(
+    Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
+  ))
+  console.log(ss, 'trace')
   console.log(traceData, 'Trace - Data')
 
   const title = chart?.layout?.title?.text

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -6,13 +6,12 @@ import {
 import { IOnboardingScatterplotSpec } from '@visahoi/core/src/scatterplot'
 
 function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec {
-  console.log(chart, 'chart data')
-  console.log(chart.layout)
+  // console.log(chart, 'chart data')
+  // console.log(chart.layout)
   const traceData = (<any>(
     Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
-  )).__data__
+  ))?.__data__
 
-  console.log(traceData[0]?.trace?.name, 'legend name')
   // const traceNodes = chart.querySelectorAll('g.points')
   // if (traceNodes === undefined || traceNodes === null) {
   //   console.error(
@@ -53,13 +52,20 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
   // const maxX = Math.max(...xVals)
   // const maxXIndex = xVals.indexOf(maxX)
   // const maxY = yVals[maxXIndex]
-
+  const title = chart?.layout?.title?.text
+  let newTitle = ''
+  // eslint-disable-next-line no-debugger
+  debugger
+  if (title.includes('(')) {
+    const id = title.indexOf('(')
+    newTitle = title.substring(0, id)
+  }
   return {
     chartTitle: {
-      value: chart?.layout?.title?.text,
+      value: (newTitle !== '') ? newTitle : title,
       anchor: {
-        findDomNodeByValue: true
-        // offset: { left: -20, top: 10 }
+        findDomNodeByValue: true,
+        offset: { left: -20, top: 10 }
       }
     },
     // type: {
@@ -83,23 +89,22 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
         findDomNodeByValue: true
         // offset: { top: -25 }
       }
-    },
-    legendTitle: {
-      value: traceData[0]?.trace?.name,
-      anchor: {
-        findDomNodeByValue: true,
-        offset: { top: 20 }
-      }
-      }
     }
-    // maxValue: {
-    //   value: maxX,
+    // legendTitle: {
+    //   value: traceData[3]?.trace?.name,
     //   anchor: {
-    //     coords: { x: maxX, y: maxY },
-    //     offset: { left: 25 }
+    //     findDomNodeByValue: true,
+    //     offset: { top: 20 }
     //   }
     // }
   }
+  // maxValue: {
+  //   value: maxX,
+  //   anchor: {
+  //     coords: { x: maxX, y: maxY },
+  //     offset: { left: 25 }
+  //   }
+  // }
 }
 
 export function scatterplotFactory (

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -50,7 +50,7 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       }
     },
     legendTitle: {
-      value: chart.data?.marker?.colorbar?.title?.text,
+      value: chart.data[0]?.marker?.colorbar?.title?.text,
       anchor: {
         findDomNodeByValue: true,
         offset: { top: 20 }

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -6,31 +6,47 @@ import {
 import { IOnboardingScatterplotSpec } from '@visahoi/core/src/scatterplot'
 
 function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec {
-  const traceNodes = chart.querySelectorAll('g.points')
-  const areaNodes = traceNodes[0].querySelectorAll('path.point')
-  const areaNodesData = Array.from(areaNodes).map(
-    (point: any) => point.__data__
-  )
-  const t = areaNodesData[0].trace
+  console.log(chart, 'chart data')
+  // const traceNodes = chart.querySelectorAll('g.points')
+  // if (traceNodes === undefined || traceNodes === null) {
+  //   console.error(
+  //     'Error: The trace is null or undefined, therefore not all onboarding messages can be shown.'
+  //   )
+  //   return {
+  //     chartTitle: {
+  //       value: chart?.layout?.title?.text,
+  //       anchor: {
+  //         findDomNodeByValue: true,
+  //         offset: { left: -20, top: 10 }
+  //       }
+  //     }
+  //   }
+  // }
 
-  const grid = document
-    .getElementsByClassName('nsewdrag drag')[0]
-    .getBoundingClientRect()
+  // const areaNodes = traceNodes[0]?.querySelectorAll('path.point')
+  // const areaNodesData = Array.from(areaNodes).map(
+  //   (point: any) => point.__data__
+  // )
+  // const t = areaNodesData[0].trace
 
-  const points = (Array.from(areaNodes) as any[]).filter(
-    (point) =>
-      point.getBoundingClientRect().x &&
-      point.getBoundingClientRect().x <= grid.width + grid.x &&
-      point.getBoundingClientRect().y &&
-      point.getBoundingClientRect().y <= grid.height + grid.y
-  )
+  // const grid = document
+  //   .getElementsByClassName('nsewdrag drag')[0]
+  //   .getBoundingClientRect()
 
-  const xVals = points.map((point) => point.getBoundingClientRect().x)
-  const yVals = points.map((point) => point.getBoundingClientRect().y)
+  // const points = (Array.from(areaNodes) as any[]).filter(
+  //   (point) =>
+  //     point.getBoundingClientRect().x &&
+  //     point.getBoundingClientRect().x <= grid.width + grid.x &&
+  //     point.getBoundingClientRect().y &&
+  //     point.getBoundingClientRect().y <= grid.height + grid.y
+  // )
 
-  const maxX = Math.max(...xVals)
-  const maxXIndex = xVals.indexOf(maxX)
-  const maxY = yVals[maxXIndex]
+  // const xVals = points.map((point) => point.getBoundingClientRect().x)
+  // const yVals = points.map((point) => point.getBoundingClientRect().y)
+
+  // const maxX = Math.max(...xVals)
+  // const maxXIndex = xVals.indexOf(maxX)
+  // const maxY = yVals[maxXIndex]
 
   return {
     chartTitle: {
@@ -40,33 +56,35 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
         offset: { left: -20, top: 10 }
       }
     },
-    type: {
-      value: t.type,
-      anchor: {
-        sel: '.points > .point:nth-child(4)'
-      }
-    },
+    // type: {
+    //   value: t.type,
+    //   anchor: {
+    //     sel: '.points > .point:nth-child(4)'
+    //   }
+    // },
     xAxisTitle: {
-      value: chart.layout.xaxis.title.text,
+      value: chart.layout.xaxis?.title.text,
       anchor: {
-        sel: '.infolayer .xtitle',
+        // sel: '.infolayer .xtitle',
+        findDomNodeByValue: true,
         offset: { left: -20 }
       }
     },
     yAxisTitle: {
-      value: chart.layout.yaxis.title.text,
+      value: chart.layout.yaxis?.title.text,
       anchor: {
-        sel: '.infolayer .ytitle',
+        // sel: '.infolayer .ytitle',
+        findDomNodeByValue: true,
         offset: { top: -25 }
       }
-    },
-    maxValue: {
-      value: maxX,
-      anchor: {
-        coords: { x: maxX, y: maxY },
-        offset: { left: 25 }
-      }
     }
+    // maxValue: {
+    //   value: maxX,
+    //   anchor: {
+    //     coords: { x: maxX, y: maxY },
+    //     offset: { left: 25 }
+    //   }
+    // }
   }
 }
 

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -72,6 +72,7 @@ export function scatterplotFactory (
   visElementId: Element
 ): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords)
+  console.log('onboardingSpec')
   return generateMessages(
     EVisualizationType.SCATTERPLOT,
     onbordingSpec,

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -68,6 +68,9 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
         offset: { left: -20, top: 10 }
       }
     },
+    title: {
+      value: title
+    },
     // type: {
     //   value: t.type,
     //   anchor: {

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -72,7 +72,7 @@ export function scatterplotFactory (
   visElementId: Element
 ): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords)
-  console.log('onboardingSpec')
+  console.log(onbordingSpec, 'onboardingSpec')
   return generateMessages(
     EVisualizationType.SCATTERPLOT,
     onbordingSpec,

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -52,8 +52,8 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
     chartTitle: {
       value: chart?.layout?.title?.text,
       anchor: {
-        findDomNodeByValue: true,
-        offset: { left: -20, top: 10 }
+        findDomNodeByValue: true
+        // offset: { left: -20, top: 10 }
       }
     },
     // type: {
@@ -66,16 +66,16 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       value: chart.layout.xaxis?.title.text,
       anchor: {
         // sel: '.infolayer .xtitle',
-        findDomNodeByValue: true,
-        offset: { left: -20 }
+        findDomNodeByValue: true
+        // offset: { left: -20 }
       }
     },
     yAxisTitle: {
       value: chart.layout.yaxis?.title.text,
       anchor: {
         // sel: '.infolayer .ytitle',
-        findDomNodeByValue: true,
-        offset: { top: -25 }
+        findDomNodeByValue: true
+        // offset: { top: -25 }
       }
     }
     // maxValue: {

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -6,6 +6,39 @@ import {
 import { IOnboardingScatterplotSpec } from '@visahoi/core/src/scatterplot'
 
 function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec {
+  const traceNodes = chart?.querySelectorAll('g.points')
+  const areaNodes = traceNodes ? traceNodes[0]?.querySelectorAll('path.point') : null
+  const areaNodesData = areaNodes
+    ? Array.from(areaNodes).map(
+      (point: any) => point.__data__
+    )
+    : null
+
+  const t = areaNodesData ? areaNodesData[0]?.trace : null
+
+  const grid = document
+    .getElementsByClassName('nsewdrag drag')[0]
+    .getBoundingClientRect()
+
+  const points = areaNodes
+    ? (Array.from(areaNodes) as any[]).filter(
+        (point) =>
+          point.getBoundingClientRect().x &&
+      point.getBoundingClientRect().x <= grid.width + grid.x &&
+      point.getBoundingClientRect().y &&
+      point.getBoundingClientRect().y <= grid.height + grid.y
+      )
+    : null
+
+  if (points) {
+    const xVals = points.map((point) => point.getBoundingClientRect().x)
+    const yVals = points.map((point) => point.getBoundingClientRect().y)
+
+    const maxX = Math.max(...xVals)
+    const maxXIndex = xVals.indexOf(maxX)
+    const maxY = yVals[maxXIndex]
+  }
+
   const title = chart?.layout?.title?.text
   const legend = chart.data[0]?.marker?.colorbar?.title?.text
   let newTitle = ''
@@ -28,6 +61,12 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
     },
     title: {
       value: title
+    },
+    type: {
+      value: t?.type,
+      anchor: {
+        sel: '.points > .point:nth-child(4)'
+      }
     },
     xAxisTitle: {
       value: chart.layout.xaxis?.title.text,

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -11,10 +11,16 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
   // ))?.__data__
 
   const title = chart?.layout?.title?.text
+  const legend = chart.data[0]?.marker?.colorbar?.title?.text
   let newTitle = ''
+  let newLegend = ''
   if (title.includes('(')) {
     const id = title.indexOf('(')
     newTitle = title.substring(0, id)
+  }
+  if (legend.includes('<')) {
+    const id = legend.indexOf('<')
+    newLegend = legend.substring(0, id)
   }
   return {
     chartTitle: {
@@ -50,7 +56,7 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       }
     },
     legendTitle: {
-      value: chart.data[0]?.marker?.colorbar?.title?.text,
+      value: newLegend,
       anchor: {
         findDomNodeByValue: true,
         offset: { top: 20 }

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -6,15 +6,13 @@ import {
 import { IOnboardingScatterplotSpec } from '@visahoi/core/src/scatterplot'
 
 function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec {
-  const traceData = (<any>(
-    Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
-  ))?.__data__
+  // const traceData = (<any>(
+  //   Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
+  // ))?.__data__
 
-  const ss = (<any>(
-    Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
-  ))
-  console.log(ss, 'trace')
-  console.log(traceData, 'Trace - Data')
+  // const ss = (<any>(
+  //   Array.from(<NodeList>chart.querySelectorAll('.traces'))[0]
+  // ))
 
   const title = chart?.layout?.title?.text
   const legend = chart.data[0]?.marker?.colorbar?.title?.text
@@ -84,7 +82,6 @@ export function scatterplotFactory (
   visElementId: Element
 ): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords)
-  console.log(onbordingSpec, 'onboardingSpec')
   return generateMessages(
     EVisualizationType.SCATTERPLOT,
     onbordingSpec,

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -15,6 +15,7 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
     : null
 
   const t = areaNodesData ? areaNodesData[0]?.trace : null
+  let maxX, maxY
 
   const grid = document
     .getElementsByClassName('nsewdrag drag')[0]
@@ -34,9 +35,9 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
     const xVals = points.map((point) => point.getBoundingClientRect().x)
     const yVals = points.map((point) => point.getBoundingClientRect().y)
 
-    const maxX = Math.max(...xVals)
+    maxX = Math.max(...xVals)
     const maxXIndex = xVals.indexOf(maxX)
-    const maxY = yVals[maxXIndex]
+    maxY = yVals[maxXIndex]
   }
 
   const title = chart?.layout?.title?.text
@@ -85,6 +86,13 @@ function extractOnboardingSpec (chart: any, coords): IOnboardingScatterplotSpec 
       anchor: {
         findDomNodeByValue: true,
         offset: { top: 20 }
+      }
+    },
+    maxValue: {
+      value: maxX,
+      anchor: {
+        coords: { x: maxX, y: maxY },
+        offset: { left: 25 }
       }
     }
   }


### PR DESCRIPTION

Summary: 
*  Add onboardings to hidden.

Note:  It doesn't contain any changes to add canvas. All the changes in this branch is merged to render-basic-messages-if-tracenodes-are-undefined-in-scatterplot