### PR TITLE
Optimize onboarding navigation behaviour

### DIFF
--- a/packages/core/src/components/Marker.svelte
+++ b/packages/core/src/components/Marker.svelte
@@ -24,17 +24,15 @@
   const handleClick = () => {
     if ($activeMarker?.marker.id === marker.id) {
       // The active marker is closed and navigation marker is not highlighted.
-      // The selectedMarker is set to the initial marker in the activeOnboarding stage.
+      // The selectedMarker is set to the active marker which is to be closed.
+      const oldActiveMarker = $activeMarker;
       activeMarker.set(null);
       const elementId = document.getElementById(
         `visahoi-marker-navigation-visahoi-marker-${marker.id}`
       );
       elementId?.style.opacity = 0.5;
 
-      const activeOnboardingStageMarkers = $markInfo.filter(
-        (m) => m.message.onboardingStage === $activeOnboardingStage
-      );
-      selectedMarker.set(activeOnboardingStageMarkers[0]);
+      selectedMarker.set(oldActiveMarker);
       $markInfo.map((marker, i) => {
         if (marker.marker.id === $selectedMarker?.marker.id) {
           markerIndexId.set(i);

--- a/packages/core/src/components/NavigationMarker.svelte
+++ b/packages/core/src/components/NavigationMarker.svelte
@@ -87,19 +87,16 @@
 
     if ($activeMarker?.marker.id === marker.id) {
       // The active marker is closed and navigation marker is not highlighted.
-      // The selectedMarker is set to the initial marker in the activeOnboarding stage.
+      // The selectedMarker is set to the active marker which is to be closed.
+      const oldActiveMarker = $activeMarker;
       activeMarker.set(null);
       const elementId = document.getElementById(
         `visahoi-marker-navigation-visahoi-marker-${marker.id}`
       );
       elementId?.style.opacity = 0.5;
 
-      const activeOnboardingStageMarkers = $markInfo.filter(
-        (m) => m.message.onboardingStage === $activeOnboardingStage
-      );
-
       // selectedMarker.set(activeOnboardingStageMarkers[0]);
-      selectedMarker.set(activeOnboardingStageMarkers[0]);
+      selectedMarker.set(oldActiveMarker);
       $markInfo.map((marker, i) => {
         if (marker.marker.id === $selectedMarker?.marker.id) {
           markerIndexId.set(i);

--- a/packages/core/src/components/Tooltip.svelte
+++ b/packages/core/src/components/Tooltip.svelte
@@ -36,16 +36,14 @@
 
   const closeTooltip = () => {
     // The active marker is closed and navigation marker is not highlighted.
-    // The selectedMarker is set to the initial marker in the activeOnboarding stage.
+    // The selectedMarker is set to the active marker which is to be closed.
+    const oldActiveMarker = $activeMarker;
     const elementId = document.getElementById(
       `visahoi-marker-navigation-visahoi-marker-${$activeMarker?.marker.id}`
     );
     elementId?.style.opacity = 0.5;
 
-    const activeOnboardingStageMarkers = $markerInformation.filter(
-      (m) => m.message.onboardingStage === $activeOnboardingStage
-    );
-    selectedMarker.set(activeOnboardingStageMarkers[0]);
+    selectedMarker.set(oldActiveMarker);
     $markerInformation.map((marker, i) => {
       if (marker.marker.id === $selectedMarker?.marker.id) {
         markerIndexId.set(i);


### PR DESCRIPTION
closes #182 

Summary: 
* The selectedMarker is set to the previous active marker which is closed.
* Before we have set the selectedMarker to always the first marker in the onboarding stage.(this is the issue)
* The up and down navigation so now opens the next marker to the selected marker.

Screencast:

https://user-images.githubusercontent.com/104566246/203796531-6de12a65-87f7-4e45-825a-9f3044c9ae12.mp4


